### PR TITLE
feat: add input validation for Edit Timer

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -62,40 +62,129 @@ describe("Focus Timer", () => {
       expect(minutesInput).not.toHaveValue("-5");
     });
 
-    it("should auto-convert seconds greater than 59", async () => {
+    it("should show error when seconds exceed 59", async () => {
       const user = userEvent.setup();
       render(<App />);
 
       await user.click(screen.getByRole("button", { name: /^edit$/i }));
 
       const secondsInput = screen.getByLabelText(/seconds/i);
-
       await user.clear(secondsInput);
       await user.type(secondsInput, "75");
 
-      const saveButton = screen.getByRole("button", { name: /save/i });
-      await user.click(saveButton);
-
-      expect(screen.getByText(/01:15/)).toBeInTheDocument();
+      expect(screen.getByText("Minutes and seconds cannot be more than 59")).toBeInTheDocument();
     });
 
-    it("should auto-convert minutes greater than 59", async () => {
+    it("should show error when minutes exceed 59", async () => {
       const user = userEvent.setup();
       render(<App />);
 
       await user.click(screen.getByRole("button", { name: /^edit$/i }));
 
       const minutesInput = screen.getByLabelText(/minutes/i);
-      const hoursInput = screen.getByLabelText(/hours/i);
-
-      await user.clear(hoursInput);
       await user.clear(minutesInput);
       await user.type(minutesInput, "75");
 
-      const saveButton = screen.getByRole("button", { name: /save/i });
-      await user.click(saveButton);
+      expect(screen.getByText("Minutes and seconds cannot be more than 59")).toBeInTheDocument();
+    });
 
-      expect(screen.getByText(/01:15:00/)).toBeInTheDocument();
+    it("should not save when minutes or seconds exceed 59", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      const minutesInput = screen.getByLabelText(/minutes/i);
+      await user.clear(minutesInput);
+      await user.type(minutesInput, "75");
+
+      await user.click(screen.getByRole("button", { name: /save/i }));
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    it("should show error when all fields are zero", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      expect(screen.getByText("Enter a value in at least one field")).toBeInTheDocument();
+    });
+
+    it("should not save when all fields are zero", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      await user.click(screen.getByRole("button", { name: /save/i }));
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    it("should show error when hours exceed 99", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      const hoursInput = screen.getByLabelText(/hours/i);
+      await user.clear(hoursInput);
+      await user.type(hoursInput, "100");
+
+      expect(screen.getByText("Hours cannot be more than 99")).toBeInTheDocument();
+    });
+
+    it("should not save when hours exceed 99", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      const hoursInput = screen.getByLabelText(/hours/i);
+      await user.clear(hoursInput);
+      await user.type(hoursInput, "100");
+
+      await user.click(screen.getByRole("button", { name: /save/i }));
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    it("should clear hours error when value is corrected to 99 or below", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      const hoursInput = screen.getByLabelText(/hours/i);
+      await user.clear(hoursInput);
+      await user.type(hoursInput, "100");
+
+      expect(screen.getByText("Hours cannot be more than 99")).toBeInTheDocument();
+
+      await user.clear(hoursInput);
+      await user.type(hoursInput, "50");
+
+      expect(screen.queryByText("Hours cannot be more than 99")).not.toBeInTheDocument();
+    });
+
+    it("should clear error when value is corrected to 59 or below", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      const minutesInput = screen.getByLabelText(/minutes/i);
+      await user.clear(minutesInput);
+      await user.type(minutesInput, "75");
+
+      expect(screen.getByText("Minutes and seconds cannot be more than 59")).toBeInTheDocument();
+
+      await user.clear(minutesInput);
+      await user.type(minutesInput, "30");
+
+      expect(screen.queryByText("Minutes and seconds cannot be more than 59")).not.toBeInTheDocument();
     });
   });
 

--- a/src/EditTimer.tsx
+++ b/src/EditTimer.tsx
@@ -11,11 +11,17 @@ export default function EditTimer({ onSave, onClose }: EditTimerProps) {
   const [seconds, setSeconds] = useState("");
 
   function handleChange(value: string): string {
-    const filtered = value.replace(/[^0-9]/g, "");
-    return filtered;
+    return value.replace(/[^0-9]/g, "");
   }
 
+  const hoursExceeded = Number(hours) > 99;
+  const minutesExceeded = Number(minutes) > 59;
+  const secondsExceeded = Number(seconds) > 59;
+  const allZero = (Number(hours) || 0) === 0 && (Number(minutes) || 0) === 0 && (Number(seconds) || 0) === 0;
+  const hasError = hoursExceeded || minutesExceeded || secondsExceeded || allZero;
+
   function handleSave() {
+    if (hasError) return;
     const h = Number(hours) || 0;
     const m = Number(minutes) || 0;
     const s = Number(seconds) || 0;
@@ -33,39 +39,48 @@ export default function EditTimer({ onSave, onClose }: EditTimerProps) {
         <h2 className="text-lg sm:text-xl font-bold text-gray-800">Edit Timer</h2>
         <div className="flex gap-3 sm:gap-4 justify-center">
           <div className="flex flex-col items-center gap-1">
-            <label htmlFor="hours" className="text-xs text-[#6b7280] uppercase tracking-wider">
+            <label htmlFor="hours" className="text-xs text-muted uppercase tracking-wider">
               Hours
             </label>
             <input
               id="hours"
-              className="w-16 sm:w-20 bg-gray-50 border border-gray-200 rounded-xl px-2 py-2 text-center text-gray-800 text-base sm:text-lg focus:outline-none focus:border-[#7c5cff]/50 focus:ring-1 focus:ring-[#7c5cff]/25 transition-all"
+              className={`w-16 sm:w-20 bg-gray-50 border rounded-xl px-2 py-2 text-center text-gray-800 text-base sm:text-lg focus:outline-none transition-all ${hoursExceeded ? "border-red-500 focus:border-red-500 focus:ring-1 focus:ring-red-500/25" : "border-gray-200 focus:border-primary/50 focus:ring-1 focus:ring-primary/25"}`}
               value={hours}
               onChange={(e) => setHours(handleChange(e.target.value))}
             />
           </div>
           <div className="flex flex-col items-center gap-1">
-            <label htmlFor="minutes" className="text-xs text-[#6b7280] uppercase tracking-wider">
+            <label htmlFor="minutes" className="text-xs text-muted uppercase tracking-wider">
               Minutes
             </label>
             <input
               id="minutes"
-              className="w-16 sm:w-20 bg-gray-50 border border-gray-200 rounded-xl px-2 py-2 text-center text-gray-800 text-base sm:text-lg focus:outline-none focus:border-[#7c5cff]/50 focus:ring-1 focus:ring-[#7c5cff]/25 transition-all"
+              className={`w-16 sm:w-20 bg-gray-50 border rounded-xl px-2 py-2 text-center text-gray-800 text-base sm:text-lg focus:outline-none transition-all ${minutesExceeded ? "border-red-500 focus:border-red-500 focus:ring-1 focus:ring-red-500/25" : "border-gray-200 focus:border-primary/50 focus:ring-1 focus:ring-primary/25"}`}
               value={minutes}
               onChange={(e) => setMinutes(handleChange(e.target.value))}
             />
           </div>
           <div className="flex flex-col items-center gap-1">
-            <label htmlFor="seconds" className="text-xs text-[#6b7280] uppercase tracking-wider">
+            <label htmlFor="seconds" className="text-xs text-muted uppercase tracking-wider">
               Seconds
             </label>
             <input
               id="seconds"
-              className="w-16 sm:w-20 bg-gray-50 border border-gray-200 rounded-xl px-2 py-2 text-center text-gray-800 text-base sm:text-lg focus:outline-none focus:border-[#7c5cff]/50 focus:ring-1 focus:ring-[#7c5cff]/25 transition-all"
+              className={`w-16 sm:w-20 bg-gray-50 border rounded-xl px-2 py-2 text-center text-gray-800 text-base sm:text-lg focus:outline-none transition-all ${secondsExceeded ? "border-red-500 focus:border-red-500 focus:ring-1 focus:ring-red-500/25" : "border-gray-200 focus:border-primary/50 focus:ring-1 focus:ring-primary/25"}`}
               value={seconds}
               onChange={(e) => setSeconds(handleChange(e.target.value))}
             />
           </div>
         </div>
+        {hoursExceeded && (
+          <p className="text-red-500 text-xs text-center">Hours cannot be more than 99</p>
+        )}
+        {(minutesExceeded || secondsExceeded) && (
+          <p className="text-red-500 text-xs text-center">Minutes and seconds cannot be more than 59</p>
+        )}
+        {allZero && (
+          <p className="text-red-500 text-xs text-center">Enter a value in at least one field</p>
+        )}
         <div className="flex gap-3 justify-end">
           <button
             className="px-4 sm:px-5 py-2 sm:py-2.5 bg-gray-100 hover:bg-gray-200 text-gray-600 hover:text-gray-800 text-sm sm:text-base rounded-xl transition-all duration-200 hover:scale-105 active:scale-95 cursor-pointer"
@@ -74,7 +89,7 @@ export default function EditTimer({ onSave, onClose }: EditTimerProps) {
             Cancel
           </button>
           <button
-            className="px-4 sm:px-5 py-2 sm:py-2.5 bg-[#7c5cff] hover:bg-[#6a4aee] text-white text-sm sm:text-base font-semibold rounded-xl transition-all duration-200 hover:scale-105 active:scale-95 shadow-lg shadow-[#7c5cff]/25 cursor-pointer"
+            className="px-4 sm:px-5 py-2 sm:py-2.5 bg-primary hover:bg-primary-hover text-white text-sm sm:text-base font-semibold rounded-xl transition-all duration-200 hover:scale-105 active:scale-95 shadow-lg shadow-primary/25 cursor-pointer"
             onClick={handleSave}
           >
             Save


### PR DESCRIPTION
## Summary
- Cap hours at 99, minutes and seconds at 59 with instant error messages
- Require at least one field to have a non-zero value
- Show red border on invalid inputs
- Replace raw hex colors with theme aliases
- Add 9 new validation tests (33 total)

## Test plan
- [x] Enter hours > 99 — error message appears immediately
- [x] Enter minutes/seconds > 59 — error message appears immediately
- [x] Leave all fields empty/zero — error shown, save blocked
- [x] Correct invalid value — error clears instantly
- [x] All 33 tests pass (`pnpm test`)

Closes #1