### PR TITLE
fix: implement Space keyboard shortcut for start/pause/resume

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -622,4 +622,64 @@ describe("Focus Timer", () => {
       vi.useRealTimers();
     });
   });
+
+  describe("Space Keyboard Shortcut", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("should start an idle timer when Space is pressed", () => {
+      render(<App />);
+
+      fireEvent.keyDown(window, { code: "Space" });
+
+      act(() => { vi.advanceTimersByTime(1000); });
+
+      expect(screen.getByText("00:01:59")).toBeInTheDocument();
+    });
+
+    it("should pause a running timer when Space is pressed", () => {
+      render(<App />);
+
+      fireEvent.keyDown(window, { code: "Space" });
+
+      act(() => { vi.advanceTimersByTime(3000); });
+
+      fireEvent.keyDown(window, { code: "Space" });
+
+      act(() => { vi.advanceTimersByTime(5000); });
+
+      expect(screen.getByText("00:01:57")).toBeInTheDocument();
+    });
+
+    it("should resume a paused timer when Space is pressed", () => {
+      render(<App />);
+
+      fireEvent.keyDown(window, { code: "Space" });
+      act(() => { vi.advanceTimersByTime(3000); });
+
+      fireEvent.keyDown(window, { code: "Space" });
+
+      fireEvent.keyDown(window, { code: "Space" });
+      act(() => { vi.advanceTimersByTime(2000); });
+
+      expect(screen.getByText("00:01:55")).toBeInTheDocument();
+    });
+
+    it("should not trigger when an input field is focused", async () => {
+      render(<App />);
+
+      fireEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      const minutesInput = screen.getByLabelText(/minutes/i);
+      fireEvent.keyDown(minutesInput, { code: "Space" });
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByText("00:02:00")).toBeInTheDocument();
+    });
+  });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,6 +122,44 @@ export default function App() {
     setTimers((prev) => prev.filter((t) => t.id !== id));
   }, []);
 
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.code !== "Space") return;
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+
+      e.preventDefault();
+
+      setTimers((prev) => {
+        const running = prev.find((t) => t.status === "running");
+        if (running) {
+          return prev.map((t) =>
+            t.id === running.id ? { ...t, status: "paused" as const } : t
+          );
+        }
+
+        const paused = prev.find((t) => t.status === "paused");
+        if (paused) {
+          return prev.map((t) =>
+            t.id === paused.id ? { ...t, status: "running" as const } : t
+          );
+        }
+
+        const idle = prev.find((t) => t.status === "idle" && t.timeLeft > 0);
+        if (idle) {
+          return prev.map((t) =>
+            t.id === idle.id ? { ...t, status: "running" as const } : t
+          );
+        }
+
+        return prev;
+      });
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
   const handleAddTimer = useCallback(() => {
     setTimers((prev) => [...prev, createTimer()]);
   }, []);


### PR DESCRIPTION
## Summary
- Space starts idle timer, pauses running, resumes paused
- Ignores Space when focused on input/textarea/select fields
- Prevents default page scroll on Space
- With multiple timers, controls the first running/paused/idle timer
- Add 4 new tests for keyboard shortcut behavior (45 total)

## Test plan
- [ ] Press Space with idle timer → starts
- [ ] Press Space with running timer → pauses
- [ ] Press Space with paused timer → resumes
- [ ] Press Space while focused on input → does nothing
- [ ] Page does not scroll on Space
- [ ] All 45 tests pass

Closes #3