### PR TITLE
fix: pre-fill edit modal with current timer value

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -36,6 +36,17 @@ describe("Focus Timer", () => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
     });
 
+    it("should pre-fill fields with current timer value", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      await user.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      expect(screen.getByLabelText(/hours/i)).toHaveValue("0");
+      expect(screen.getByLabelText(/minutes/i)).toHaveValue("2");
+      expect(screen.getByLabelText(/seconds/i)).toHaveValue("0");
+    });
+
     it("should only accept numbers, not letters or special characters", async () => {
       const user = userEvent.setup();
       render(<App />);
@@ -109,6 +120,10 @@ describe("Focus Timer", () => {
 
       await user.click(screen.getByRole("button", { name: /^edit$/i }));
 
+      await user.clear(screen.getByLabelText(/hours/i));
+      await user.clear(screen.getByLabelText(/minutes/i));
+      await user.clear(screen.getByLabelText(/seconds/i));
+
       expect(screen.getByText("Enter a value in at least one field")).toBeInTheDocument();
     });
 
@@ -117,6 +132,10 @@ describe("Focus Timer", () => {
       render(<App />);
 
       await user.click(screen.getByRole("button", { name: /^edit$/i }));
+
+      await user.clear(screen.getByLabelText(/hours/i));
+      await user.clear(screen.getByLabelText(/minutes/i));
+      await user.clear(screen.getByLabelText(/seconds/i));
 
       await user.click(screen.getByRole("button", { name: /save/i }));
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -254,6 +254,7 @@ export default function App() {
 
       {editingId && (
         <EditTimer
+          initialTime={timers.find((t) => t.id === editingId)?.initialTime ?? 0}
           onSave={(totalSeconds) => {
             updateTimer(editingId, {
               timeLeft: totalSeconds,

--- a/src/EditTimer.tsx
+++ b/src/EditTimer.tsx
@@ -1,14 +1,15 @@
 import { useState } from "react";
 
 interface EditTimerProps {
+  initialTime: number;
   onSave: (totalSeconds: number) => void;
   onClose: () => void;
 }
 
-export default function EditTimer({ onSave, onClose }: EditTimerProps) {
-  const [hours, setHours] = useState("");
-  const [minutes, setMinutes] = useState("");
-  const [seconds, setSeconds] = useState("");
+export default function EditTimer({ initialTime, onSave, onClose }: EditTimerProps) {
+  const [hours, setHours] = useState(String(Math.floor(initialTime / 3600)));
+  const [minutes, setMinutes] = useState(String(Math.floor((initialTime % 3600) / 60)));
+  const [seconds, setSeconds] = useState(String(initialTime % 60));
 
   function handleChange(value: string): string {
     return value.replace(/[^0-9]/g, "");


### PR DESCRIPTION
## Summary
- Pass initialTime to EditTimer component
- Pre-fill hours, minutes, seconds from current timer
- Update existing tests to account for pre-filled values
- Add test verifying pre-fill behavior (46 total)

## Test plan
- [ ] Open edit modal on default timer → shows 0h, 2m, 0s
- [ ] Edit a value and save → timer updates correctly
- [ ] All 46 tests pass

Closes #6