### PR TITLE
feat: add timer labels with inline editing

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -83,7 +83,9 @@ describe("Focus Timer", () => {
       await user.clear(secondsInput);
       await user.type(secondsInput, "75");
 
-      expect(screen.getByText("Minutes and seconds cannot be more than 59")).toBeInTheDocument();
+      expect(
+        screen.getByText("Minutes and seconds cannot be more than 59")
+      ).toBeInTheDocument();
     });
 
     it("should show error when minutes exceed 59", async () => {
@@ -96,7 +98,9 @@ describe("Focus Timer", () => {
       await user.clear(minutesInput);
       await user.type(minutesInput, "75");
 
-      expect(screen.getByText("Minutes and seconds cannot be more than 59")).toBeInTheDocument();
+      expect(
+        screen.getByText("Minutes and seconds cannot be more than 59")
+      ).toBeInTheDocument();
     });
 
     it("should not save when minutes or seconds exceed 59", async () => {
@@ -124,7 +128,9 @@ describe("Focus Timer", () => {
       await user.clear(screen.getByLabelText(/minutes/i));
       await user.clear(screen.getByLabelText(/seconds/i));
 
-      expect(screen.getByText("Enter a value in at least one field")).toBeInTheDocument();
+      expect(
+        screen.getByText("Enter a value in at least one field")
+      ).toBeInTheDocument();
     });
 
     it("should not save when all fields are zero", async () => {
@@ -152,7 +158,9 @@ describe("Focus Timer", () => {
       await user.clear(hoursInput);
       await user.type(hoursInput, "100");
 
-      expect(screen.getByText("Hours cannot be more than 99")).toBeInTheDocument();
+      expect(
+        screen.getByText("Hours cannot be more than 99")
+      ).toBeInTheDocument();
     });
 
     it("should not save when hours exceed 99", async () => {
@@ -180,12 +188,16 @@ describe("Focus Timer", () => {
       await user.clear(hoursInput);
       await user.type(hoursInput, "100");
 
-      expect(screen.getByText("Hours cannot be more than 99")).toBeInTheDocument();
+      expect(
+        screen.getByText("Hours cannot be more than 99")
+      ).toBeInTheDocument();
 
       await user.clear(hoursInput);
       await user.type(hoursInput, "50");
 
-      expect(screen.queryByText("Hours cannot be more than 99")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Hours cannot be more than 99")
+      ).not.toBeInTheDocument();
     });
 
     it("should clear error when value is corrected to 59 or below", async () => {
@@ -198,12 +210,16 @@ describe("Focus Timer", () => {
       await user.clear(minutesInput);
       await user.type(minutesInput, "75");
 
-      expect(screen.getByText("Minutes and seconds cannot be more than 59")).toBeInTheDocument();
+      expect(
+        screen.getByText("Minutes and seconds cannot be more than 59")
+      ).toBeInTheDocument();
 
       await user.clear(minutesInput);
       await user.type(minutesInput, "30");
 
-      expect(screen.queryByText("Minutes and seconds cannot be more than 59")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Minutes and seconds cannot be more than 59")
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -212,6 +228,51 @@ describe("Focus Timer", () => {
       render(<App />);
       expect(screen.getByText("Sessions:")).toBeInTheDocument();
       expect(screen.getByText("0")).toBeInTheDocument();
+    });
+  });
+
+  describe("Timer Label", () => {
+    it("should display default label ", () => {
+      render(<App />);
+      expect(screen.getByText(/Timer \d+/)).toBeInTheDocument();
+    });
+    it("should become editable when clicked", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+      await user.click(
+        screen.getByRole("button", { name: /click to edit label/i })
+      );
+      expect(screen.getByLabelText(/edit timer label/i)).toBeInTheDocument();
+    });
+    it("should save new label on Enter", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+      const label = screen.getByRole("button", {
+        name: /click to edit label/i,
+      });
+      await user.click(label);
+      const input = screen.getByLabelText(/edit timer label/i);
+      await user.clear(input);
+      await user.type(input, "work");
+      await user.keyboard("{Enter}");
+      expect(screen.getByText("work")).toBeInTheDocument();
+    });
+    it("should save new label on Escape", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+      const label = screen.getByRole("button", {
+        name: /click to edit label/i,
+      });
+      const originalText = label.textContent;
+      await user.click(label);
+      const input = screen.getByLabelText(/edit timer label/i);
+      await user.clear(input);
+
+      await user.type(input, "Something Else");
+
+      await user.keyboard("{Escape}");
+
+      expect(screen.getByText(originalText!)).toBeInTheDocument();
     });
   });
 
@@ -462,14 +523,9 @@ describe("Focus Timer", () => {
     it("should show delete button only when multiple timers exist", () => {
       render(<App />);
 
-
-      expect(
-        screen.queryByTitle("Remove timer")
-      ).not.toBeInTheDocument();
-
+      expect(screen.queryByTitle("Remove timer")).not.toBeInTheDocument();
 
       fireEvent.click(screen.getByRole("button", { name: /add timer/i }));
-
 
       const deleteButtons = screen.getAllByTitle("Remove timer");
       expect(deleteButtons.length).toBeGreaterThan(0);
@@ -478,10 +534,8 @@ describe("Focus Timer", () => {
     it("should remove a timer when delete is clicked", () => {
       render(<App />);
 
-
       fireEvent.click(screen.getByRole("button", { name: /add timer/i }));
       expect(screen.getAllByText("00:02:00")).toHaveLength(2);
-
 
       fireEvent.click(screen.getAllByTitle("Remove timer")[0]);
       expect(screen.getAllByText("00:02:00")).toHaveLength(1);
@@ -492,9 +546,7 @@ describe("Focus Timer", () => {
 
       render(<App />);
 
-
       fireEvent.click(screen.getByRole("button", { name: /add timer/i }));
-
 
       const startButtons = screen.getAllByRole("button", { name: /start/i });
       fireEvent.click(startButtons[0]);
@@ -502,7 +554,6 @@ describe("Focus Timer", () => {
       act(() => {
         vi.advanceTimersByTime(5000);
       });
-
 
       expect(screen.getByText("00:01:55")).toBeInTheDocument();
       expect(screen.getByText("00:02:00")).toBeInTheDocument();
@@ -514,21 +565,17 @@ describe("Focus Timer", () => {
       const user = userEvent.setup();
       render(<App />);
 
-
       await user.click(screen.getByRole("button", { name: /add timer/i }));
-
 
       const editButtons = screen.getAllByRole("button", { name: /^edit$/i });
       await user.click(editButtons[0]);
 
       expect(screen.getByRole("dialog")).toBeInTheDocument();
 
-
       const minutesInput = screen.getByLabelText(/minutes/i);
       await user.clear(minutesInput);
       await user.type(minutesInput, "5");
       await user.click(screen.getByRole("button", { name: /save/i }));
-
 
       expect(screen.getByText("00:05:00")).toBeInTheDocument();
       expect(screen.getByText("00:02:00")).toBeInTheDocument();
@@ -540,7 +587,9 @@ describe("Focus Timer", () => {
       const user = userEvent.setup();
       render(<App />);
 
-      await user.click(screen.getByRole("button", { name: /click to edit time/i }));
+      await user.click(
+        screen.getByRole("button", { name: /click to edit time/i })
+      );
 
       expect(screen.getByLabelText(/edit hours/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/edit minutes/i)).toBeInTheDocument();
@@ -552,14 +601,18 @@ describe("Focus Timer", () => {
 
       fireEvent.click(screen.getByRole("button", { name: /start/i }));
 
-      expect(screen.queryByRole("button", { name: /click to edit time/i })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /click to edit time/i })
+      ).not.toBeInTheDocument();
     });
 
     it("should save new value on Enter", async () => {
       const user = userEvent.setup();
       render(<App />);
 
-      await user.click(screen.getByRole("button", { name: /click to edit time/i }));
+      await user.click(
+        screen.getByRole("button", { name: /click to edit time/i })
+      );
 
       const minutesInput = screen.getByLabelText(/edit minutes/i);
       await user.clear(minutesInput);
@@ -573,7 +626,9 @@ describe("Focus Timer", () => {
       const user = userEvent.setup();
       render(<App />);
 
-      await user.click(screen.getByRole("button", { name: /click to edit time/i }));
+      await user.click(
+        screen.getByRole("button", { name: /click to edit time/i })
+      );
 
       const minutesInput = screen.getByLabelText(/edit minutes/i);
       await user.clear(minutesInput);
@@ -587,7 +642,9 @@ describe("Focus Timer", () => {
       const user = userEvent.setup();
       render(<App />);
 
-      await user.click(screen.getByRole("button", { name: /click to edit time/i }));
+      await user.click(
+        screen.getByRole("button", { name: /click to edit time/i })
+      );
 
       const minutesInput = screen.getByLabelText(/edit minutes/i);
       await user.clear(minutesInput);
@@ -602,7 +659,9 @@ describe("Focus Timer", () => {
       const user = userEvent.setup();
       render(<App />);
 
-      await user.click(screen.getByRole("button", { name: /click to edit time/i }));
+      await user.click(
+        screen.getByRole("button", { name: /click to edit time/i })
+      );
 
       const minutesInput = screen.getByLabelText(/edit minutes/i);
       await user.clear(minutesInput);
@@ -615,7 +674,9 @@ describe("Focus Timer", () => {
       const user = userEvent.setup();
       render(<App />);
 
-      await user.click(screen.getByRole("button", { name: /click to edit time/i }));
+      await user.click(
+        screen.getByRole("button", { name: /click to edit time/i })
+      );
 
       const hoursInput = screen.getByLabelText(/edit hours/i);
       const minutesInput = screen.getByLabelText(/edit minutes/i);
@@ -633,10 +694,14 @@ describe("Focus Timer", () => {
       render(<App />);
 
       fireEvent.click(screen.getByRole("button", { name: /start/i }));
-      act(() => { vi.advanceTimersByTime(1000); });
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
       fireEvent.click(screen.getByRole("button", { name: /pause/i }));
 
-      expect(screen.queryByRole("button", { name: /click to edit time/i })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /click to edit time/i })
+      ).not.toBeInTheDocument();
 
       vi.useRealTimers();
     });
@@ -656,7 +721,9 @@ describe("Focus Timer", () => {
 
       fireEvent.keyDown(window, { code: "Space" });
 
-      act(() => { vi.advanceTimersByTime(1000); });
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
 
       expect(screen.getByText("00:01:59")).toBeInTheDocument();
     });
@@ -666,11 +733,15 @@ describe("Focus Timer", () => {
 
       fireEvent.keyDown(window, { code: "Space" });
 
-      act(() => { vi.advanceTimersByTime(3000); });
+      act(() => {
+        vi.advanceTimersByTime(3000);
+      });
 
       fireEvent.keyDown(window, { code: "Space" });
 
-      act(() => { vi.advanceTimersByTime(5000); });
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
 
       expect(screen.getByText("00:01:57")).toBeInTheDocument();
     });
@@ -679,12 +750,16 @@ describe("Focus Timer", () => {
       render(<App />);
 
       fireEvent.keyDown(window, { code: "Space" });
-      act(() => { vi.advanceTimersByTime(3000); });
+      act(() => {
+        vi.advanceTimersByTime(3000);
+      });
 
       fireEvent.keyDown(window, { code: "Space" });
 
       fireEvent.keyDown(window, { code: "Space" });
-      act(() => { vi.advanceTimersByTime(2000); });
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
 
       expect(screen.getByText("00:01:55")).toBeInTheDocument();
     });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,10 @@ const DEFAULT_TIME = 120;
 
 let nextId = 1;
 function createTimer(): TimerData {
+  const id = nextId++;
   return {
-    id: String(nextId++),
+    id: String(id),
+    label: `Timer ${id}`,
     timeLeft: DEFAULT_TIME,
     initialTime: DEFAULT_TIME,
     status: "idle",
@@ -56,21 +58,21 @@ export default function App() {
       const h = Math.floor(running.timeLeft / 3600);
       const m = Math.floor((running.timeLeft % 3600) / 60);
       const s = running.timeLeft % 60;
-      const display = `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+      const display = `${String(h).padStart(2, "0")}:${String(m).padStart(
+        2,
+        "0"
+      )}:${String(s).padStart(2, "0")}`;
       document.title = `${display} — Timer`;
     } else {
       document.title = "Timer";
     }
   }, [timers]);
 
-  const updateTimer = useCallback(
-    (id: string, updates: Partial<TimerData>) => {
-      setTimers((prev) =>
-        prev.map((t) => (t.id === id ? { ...t, ...updates } : t))
-      );
-    },
-    []
-  );
+  const updateTimer = useCallback((id: string, updates: Partial<TimerData>) => {
+    setTimers((prev) =>
+      prev.map((t) => (t.id === id ? { ...t, ...updates } : t))
+    );
+  }, []);
 
   const handleStart = useCallback(
     (id: string) => updateTimer(id, { status: "running" }),
@@ -84,26 +86,20 @@ export default function App() {
     (id: string) => updateTimer(id, { status: "running" }),
     [updateTimer]
   );
-  const handleStop = useCallback(
-    (id: string) => {
-      setTimers((prev) =>
-        prev.map((t) =>
-          t.id === id ? { ...t, status: "idle", timeLeft: t.initialTime } : t
-        )
-      );
-    },
-    []
-  );
-  const handleReset = useCallback(
-    (id: string) => {
-      setTimers((prev) =>
-        prev.map((t) =>
-          t.id === id ? { ...t, status: "idle", timeLeft: t.initialTime } : t
-        )
-      );
-    },
-    []
-  );
+  const handleStop = useCallback((id: string) => {
+    setTimers((prev) =>
+      prev.map((t) =>
+        t.id === id ? { ...t, status: "idle", timeLeft: t.initialTime } : t
+      )
+    );
+  }, []);
+  const handleReset = useCallback((id: string) => {
+    setTimers((prev) =>
+      prev.map((t) =>
+        t.id === id ? { ...t, status: "idle", timeLeft: t.initialTime } : t
+      )
+    );
+  }, []);
   const handleInlineEdit = useCallback(
     (id: string, totalSeconds: number) => {
       updateTimer(id, { timeLeft: totalSeconds, initialTime: totalSeconds });
@@ -113,6 +109,14 @@ export default function App() {
   const handleDelete = useCallback((id: string) => {
     setTimers((prev) => prev.filter((t) => t.id !== id));
   }, []);
+
+  const handleLabelChange = useCallback(
+    (id: string, label: string) => {
+      updateTimer(id, { label });
+    },
+    [updateTimer]
+  );
+
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -182,13 +186,23 @@ export default function App() {
               onDelete={handleDelete}
               canDelete={false}
               solo
+              onLabelChange={handleLabelChange}
             />
           </div>
           <button
             onClick={handleAddTimer}
             className="mt-4 sm:mt-6 px-5 sm:px-8 py-2.5 sm:py-3 bg-gray-100 hover:bg-gray-200 text-muted hover:text-gray-800 text-sm sm:text-base font-semibold rounded-xl transition-all duration-200 hover:scale-105 active:scale-95 border border-gray-200 cursor-pointer flex items-center gap-2"
           >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
               <circle cx="12" cy="12" r="10" />
               <line x1="12" y1="8" x2="12" y2="16" />
               <line x1="8" y1="12" x2="16" y2="12" />
@@ -211,6 +225,7 @@ export default function App() {
               onInlineEdit={handleInlineEdit}
               onDelete={handleDelete}
               canDelete
+              onLabelChange={handleLabelChange}
             />
           ))}
 
@@ -260,3 +275,5 @@ export default function App() {
     </div>
   );
 }
+
+

--- a/src/TimerCard.tsx
+++ b/src/TimerCard.tsx
@@ -6,6 +6,7 @@ export type TimerStatus = "idle" | "running" | "paused";
 
 export interface TimerData {
   id: string;
+  label: string;
   timeLeft: number;
   initialTime: number;
   status: TimerStatus;
@@ -22,6 +23,7 @@ interface TimerCardProps {
   onEdit: (id: string) => void;
   onInlineEdit: (id: string, totalSeconds: number) => void;
   onDelete: (id: string) => void;
+  onLabelChange: (id: string, label: string) => void;
   canDelete: boolean;
   solo?: boolean;
 }
@@ -36,6 +38,7 @@ export default function TimerCard({
   onEdit,
   onInlineEdit,
   onDelete,
+  onLabelChange,
   canDelete,
   solo = false,
 }: TimerCardProps) {
@@ -48,7 +51,8 @@ export default function TimerCard({
   const [editMinutes, setEditMinutes] = useState("");
   const [editSeconds, setEditSeconds] = useState("");
   const editContainerRef = useRef<HTMLDivElement | null>(null);
-
+  const [isEditingLabel, setIsEditingLabel] = useState(false);
+  const [editLabel, setEditLabel] = useState("");
   const progress =
     status === "idle" ? 1 : initialTime > 0 ? timeLeft / initialTime : 0;
   const hours = Math.floor(timeLeft / 3600);
@@ -83,6 +87,23 @@ export default function TimerCard({
     setEditMinutes(String(minutes));
     setEditSeconds(String(seconds));
     setIsEditing(true);
+  }
+
+  function startLabelEdit() {
+    setEditLabel(timer.label);
+    setIsEditingLabel(true);
+  }
+
+  function saveLabelEdit() {
+    const trimmed = editLabel.trim();
+    if (trimmed) {
+      onLabelChange(id, trimmed);
+    }
+    setIsEditingLabel(false);
+  }
+
+  function cancelLabelEdit() {
+    setIsEditingLabel(false);
   }
 
   function saveEdit() {
@@ -123,7 +144,10 @@ export default function TimerCard({
   useEffect(() => {
     if (!isEditing) return;
     function handleClickOutside(e: MouseEvent) {
-      if (editContainerRef.current && !editContainerRef.current.contains(e.target as Node)) {
+      if (
+        editContainerRef.current &&
+        !editContainerRef.current.contains(e.target as Node)
+      ) {
         saveEdit();
       }
     }
@@ -144,7 +168,17 @@ export default function TimerCard({
         onStop={() => onStop(id)}
       />
     );
-  }, [isPip, display, progress, ringColor, status, id, onPause, onResume, onStop]);
+  }, [
+    isPip,
+    display,
+    progress,
+    ringColor,
+    status,
+    id,
+    onPause,
+    onResume,
+    onStop,
+  ]);
 
   async function openPip() {
     if (!supportsPip) return;
@@ -175,7 +209,9 @@ export default function TimerCard({
           } else if (sheet.cssRules) {
             const style = pipWindow.document.createElement("style");
             for (const rule of sheet.cssRules) {
-              style.appendChild(pipWindow.document.createTextNode(rule.cssText));
+              style.appendChild(
+                pipWindow.document.createTextNode(rule.cssText)
+              );
             }
             pipWindow.document.head.appendChild(style);
           }
@@ -220,7 +256,13 @@ export default function TimerCard({
   }
 
   return (
-    <div className={`relative rounded-2xl sm:rounded-3xl border border-glass-border bg-glass backdrop-blur-xl shadow-2xl flex flex-col items-center ${solo ? "p-5 sm:p-8 lg:p-10 gap-4 sm:gap-6 lg:gap-8" : "p-5 sm:p-6 gap-3 sm:gap-4"}`}>
+    <div
+      className={`relative rounded-2xl sm:rounded-3xl border border-glass-border bg-glass backdrop-blur-xl shadow-2xl flex flex-col items-center ${
+        solo
+          ? "p-5 sm:p-8 lg:p-10 gap-4 sm:gap-6 lg:gap-8"
+          : "p-5 sm:p-6 gap-3 sm:gap-4"
+      }`}
+    >
       <div className="flex w-full justify-between items-center">
         <div>
           {supportsPip && (
@@ -229,9 +271,27 @@ export default function TimerCard({
               title="Pop out timer"
               className="p-1.5 text-muted hover:text-primary transition-colors cursor-pointer"
             >
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
                 <rect x="2" y="3" width="20" height="14" rx="2" />
-                <rect x="12" y="9" width="8" height="8" rx="1" fill="currentColor" opacity="0.2" stroke="currentColor" />
+                <rect
+                  x="12"
+                  y="9"
+                  width="8"
+                  height="8"
+                  rx="1"
+                  fill="currentColor"
+                  opacity="0.2"
+                  stroke="currentColor"
+                />
               </svg>
             </button>
           )}
@@ -242,18 +302,61 @@ export default function TimerCard({
             title="Remove timer"
             className="p-1.5 text-muted hover:text-danger transition-colors cursor-pointer"
           >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
               <line x1="18" y1="6" x2="6" y2="18" />
               <line x1="6" y1="6" x2="18" y2="18" />
             </svg>
           </button>
         )}
       </div>
+      <div>
+        {isEditingLabel ? (
+          <input
+            aria-label="edit timer label"
+            autoFocus
+            maxLength={20}
+            className="text-center text-sm text-muted bg-transparent border-b-2 border-primary outline-none px-2 py-1"
+            value={editLabel}
+            onChange={(e) => setEditLabel(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") saveLabelEdit();
+              if (e.key === "Escape") cancelLabelEdit();
+            }}
+            onBlur={saveLabelEdit}
+          />
+        ) : (
+          <span
+            className="text-sm text-muted cursor-pointer hover:text-primary transition-colors"
+            onClick={startLabelEdit}
+            role="button"
+            aria-label="Click to edit label"
+          >
+            {timer.label}
+          </span>
+        )}
+      </div>
 
-      <div className={`relative flex items-center justify-center ${solo ? "w-52 h-52 sm:w-72 sm:h-72 lg:w-96 lg:h-96" : "w-40 h-40 sm:w-48 sm:h-48"}`}>
+      <div
+        className={`relative flex items-center justify-center ${
+          solo
+            ? "w-52 h-52 sm:w-72 sm:h-72 lg:w-96 lg:h-96"
+            : "w-40 h-40 sm:w-48 sm:h-48"
+        }`}
+      >
         <svg
           viewBox={`0 0 ${svgSize} ${svgSize}`}
-          className={`w-full h-full ${status === "running" ? "progress-ring-animated" : ""}`}
+          className={`w-full h-full ${
+            status === "running" ? "progress-ring-animated" : ""
+          }`}
         >
           <circle
             cx={radius + stroke}
@@ -283,32 +386,72 @@ export default function TimerCard({
         </svg>
         <div className="absolute inset-0 flex flex-col items-center justify-center">
           {isEditing ? (
-            <div ref={editContainerRef} className="flex items-center gap-1" onKeyDown={handleEditKeyDown}>
+            <div
+              ref={editContainerRef}
+              className="flex items-center gap-1"
+              onKeyDown={handleEditKeyDown}
+            >
               <input
                 aria-label="edit hours"
                 autoFocus
-                className={`bg-transparent text-center font-bold text-gray-800 font-mono border-b-2 border-primary outline-none ${solo ? "w-12 sm:w-16 lg:w-20 text-3xl sm:text-5xl lg:text-6xl" : "w-8 sm:w-12 text-2xl sm:text-3xl"}`}
+                className={`bg-transparent text-center font-bold text-gray-800 font-mono border-b-2 border-primary outline-none ${
+                  solo
+                    ? "w-12 sm:w-16 lg:w-20 text-3xl sm:text-5xl lg:text-6xl"
+                    : "w-8 sm:w-12 text-2xl sm:text-3xl"
+                }`}
                 value={editHours}
                 onChange={(e) => setEditHours(filterNumeric(e.target.value))}
               />
-              <span className={`font-bold text-gray-800 font-mono ${solo ? "text-3xl sm:text-5xl lg:text-6xl" : "text-2xl sm:text-3xl"}`}>:</span>
+              <span
+                className={`font-bold text-gray-800 font-mono ${
+                  solo
+                    ? "text-3xl sm:text-5xl lg:text-6xl"
+                    : "text-2xl sm:text-3xl"
+                }`}
+              >
+                :
+              </span>
               <input
                 aria-label="edit minutes"
-                className={`bg-transparent text-center font-bold text-gray-800 font-mono border-b-2 border-primary outline-none ${solo ? "w-12 sm:w-16 lg:w-20 text-3xl sm:text-5xl lg:text-6xl" : "w-8 sm:w-12 text-2xl sm:text-3xl"}`}
+                className={`bg-transparent text-center font-bold text-gray-800 font-mono border-b-2 border-primary outline-none ${
+                  solo
+                    ? "w-12 sm:w-16 lg:w-20 text-3xl sm:text-5xl lg:text-6xl"
+                    : "w-8 sm:w-12 text-2xl sm:text-3xl"
+                }`}
                 value={editMinutes}
                 onChange={(e) => setEditMinutes(filterNumeric(e.target.value))}
               />
-              <span className={`font-bold text-gray-800 font-mono ${solo ? "text-3xl sm:text-5xl lg:text-6xl" : "text-2xl sm:text-3xl"}`}>:</span>
+              <span
+                className={`font-bold text-gray-800 font-mono ${
+                  solo
+                    ? "text-3xl sm:text-5xl lg:text-6xl"
+                    : "text-2xl sm:text-3xl"
+                }`}
+              >
+                :
+              </span>
               <input
                 aria-label="edit seconds"
-                className={`bg-transparent text-center font-bold text-gray-800 font-mono border-b-2 border-primary outline-none ${solo ? "w-12 sm:w-16 lg:w-20 text-3xl sm:text-5xl lg:text-6xl" : "w-8 sm:w-12 text-2xl sm:text-3xl"}`}
+                className={`bg-transparent text-center font-bold text-gray-800 font-mono border-b-2 border-primary outline-none ${
+                  solo
+                    ? "w-12 sm:w-16 lg:w-20 text-3xl sm:text-5xl lg:text-6xl"
+                    : "w-8 sm:w-12 text-2xl sm:text-3xl"
+                }`}
                 value={editSeconds}
                 onChange={(e) => setEditSeconds(filterNumeric(e.target.value))}
               />
             </div>
           ) : (
             <span
-              className={`font-bold text-gray-800 tracking-widest font-mono ${solo ? "text-3xl sm:text-5xl lg:text-6xl" : "text-2xl sm:text-3xl"} ${status === "idle" ? "cursor-pointer hover:text-primary transition-colors" : ""}`}
+              className={`font-bold text-gray-800 tracking-widest font-mono ${
+                solo
+                  ? "text-3xl sm:text-5xl lg:text-6xl"
+                  : "text-2xl sm:text-3xl"
+              } ${
+                status === "idle"
+                  ? "cursor-pointer hover:text-primary transition-colors"
+                  : ""
+              }`}
               onClick={startEditing}
               role={status === "idle" ? "button" : undefined}
               aria-label={status === "idle" ? "Click to edit time" : undefined}
@@ -385,7 +528,8 @@ export default function TimerCard({
           />
         </svg>
         <span>
-          Sessions: <span className="text-gray-800 font-semibold">{sessions}</span>
+          Sessions:{" "}
+          <span className="text-gray-800 font-semibold">{sessions}</span>
         </span>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Each timer displays a default label (Timer 1, Timer 2, etc.)
- Click label to edit, Enter saves, Escape reverts, blur saves
- Max 20 character limit enforced
- Add 4 new tests for label feature (50 total)

## Test plan
- [ ] Default label "Timer 1" is displayed
- [ ] Click label → becomes editable
- [ ] Enter saves, Escape reverts, blur saves
- [ ] All 50 tests pass

Closes #4