### PR TITLE
refactor: extract shared timer utilities into src/utils/timerUtils.ts

### DIFF
--- a/src/EditTimer.tsx
+++ b/src/EditTimer.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { filterNumericInput, secondsToHMS, hmsToSeconds } from "./utils/timerUtils";
 
 interface EditTimerProps {
   initialTime: number;
@@ -11,15 +12,10 @@ export default function EditTimer({
   onSave,
   onClose,
 }: EditTimerProps) {
-  const [hours, setHours] = useState(String(Math.floor(initialTime / 3600)));
-  const [minutes, setMinutes] = useState(
-    String(Math.floor((initialTime % 3600) / 60))
-  );
-  const [seconds, setSeconds] = useState(String(initialTime % 60));
-
-  function handleChange(value: string): string {
-    return value.replace(/[^0-9]/g, "");
-  }
+  const initial = secondsToHMS(initialTime);
+  const [hours, setHours] = useState(String(initial.hours));
+  const [minutes, setMinutes] = useState(String(initial.minutes));
+  const [seconds, setSeconds] = useState(String(initial.seconds));
 
   const hoursExceeded = Number(hours) > 99;
   const minutesExceeded = Number(minutes) > 59;
@@ -37,7 +33,7 @@ export default function EditTimer({
     const m = Number(minutes) || 0;
     const s = Number(seconds) || 0;
 
-    const totalSeconds = h * 3600 + m * 60 + s;
+    const totalSeconds = hmsToSeconds(h, m, s);
     onSave(totalSeconds);
   }
 
@@ -76,7 +72,7 @@ export default function EditTimer({
                   : "border-gray-200 focus:border-primary/50 focus:ring-1 focus:ring-primary/25"
               }`}
               value={hours}
-              onChange={(e) => setHours(handleChange(e.target.value))}
+              onChange={(e) => setHours(filterNumericInput(e.target.value))}
             />
           </div>
           <div className="flex flex-col items-center gap-1">
@@ -94,7 +90,7 @@ export default function EditTimer({
                   : "border-gray-200 focus:border-primary/50 focus:ring-1 focus:ring-primary/25"
               }`}
               value={minutes}
-              onChange={(e) => setMinutes(handleChange(e.target.value))}
+              onChange={(e) => setMinutes(filterNumericInput(e.target.value))}
             />
           </div>
           <div className="flex flex-col items-center gap-1">
@@ -112,7 +108,7 @@ export default function EditTimer({
                   : "border-gray-200 focus:border-primary/50 focus:ring-1 focus:ring-primary/25"
               }`}
               value={seconds}
-              onChange={(e) => setSeconds(handleChange(e.target.value))}
+              onChange={(e) => setSeconds(filterNumericInput(e.target.value))}
             />
           </div>
         </div>

--- a/src/TimerCard.tsx
+++ b/src/TimerCard.tsx
@@ -1,4 +1,12 @@
 import { useState, useEffect, useRef } from "react";
+import {
+  formatTime,
+  getRingColor,
+  calculateProgress,
+  secondsToHMS,
+  filterNumericInput,
+} from "./utils/timerUtils";
+
 import { createRoot, type Root } from "react-dom/client";
 import PipTimer from "./PipTimer";
 
@@ -46,6 +54,9 @@ export default function TimerCard({
   const pipWindowRef = useRef<Window | null>(null);
   const pipRootRef = useRef<Root | null>(null);
   const [isPip, setIsPip] = useState(false);
+  const progress = calculateProgress(status, timeLeft, initialTime);
+  const { hours, minutes, seconds } = secondsToHMS(timeLeft);
+  const display = formatTime(timeLeft);
   const [isEditing, setIsEditing] = useState(false);
   const [editHours, setEditHours] = useState("");
   const [editMinutes, setEditMinutes] = useState("");
@@ -53,30 +64,13 @@ export default function TimerCard({
   const editContainerRef = useRef<HTMLDivElement | null>(null);
   const [isEditingLabel, setIsEditingLabel] = useState(false);
   const [editLabel, setEditLabel] = useState("");
-  const progress =
-    status === "idle" ? 1 : initialTime > 0 ? timeLeft / initialTime : 0;
-  const hours = Math.floor(timeLeft / 3600);
-  const minutes = Math.floor((timeLeft % 3600) / 60);
-  const seconds = timeLeft % 60;
-  const display = `${String(hours).padStart(2, "0")}:${String(minutes).padStart(
-    2,
-    "0"
-  )}:${String(seconds).padStart(2, "0")}`;
-
   const radius = solo ? 140 : 100;
   const stroke = solo ? 8 : 6;
   const svgSize = radius * 2 + stroke * 2;
   const circumference = 2 * Math.PI * radius;
   const dashOffset = circumference * (1 - progress);
 
-  const ringColor =
-    status === "idle"
-      ? "#7c5cff"
-      : timeLeft <= 5
-      ? "#ef4444"
-      : timeLeft <= 10
-      ? "#eab308"
-      : "#7c5cff";
+  const ringColor = getRingColor(status, timeLeft);
 
   const supportsPip =
     typeof window !== "undefined" && "documentPictureInPicture" in window;
@@ -135,10 +129,6 @@ export default function TimerCard({
       e.preventDefault();
       cancelEdit();
     }
-  }
-
-  function filterNumeric(value: string): string {
-    return value.replace(/[^0-9]/g, "");
   }
 
   useEffect(() => {
@@ -215,7 +205,9 @@ export default function TimerCard({
             }
             pipWindow.document.head.appendChild(style);
           }
-        } catch { /* ignore pip styling errors */ }
+        } catch {
+          /* ignore pip styling errors */
+        }
       }
 
       const fontLinks = document.querySelectorAll(
@@ -252,7 +244,9 @@ export default function TimerCard({
         pipWindowRef.current = null;
         setIsPip(false);
       });
-    } catch { /* ignore pip styling errors */ }
+    } catch {
+      /* ignore pip styling errors */
+    }
   }
 
   return (
@@ -402,7 +396,9 @@ export default function TimerCard({
                     : "w-8 sm:w-12 text-2xl sm:text-3xl"
                 }`}
                 value={editHours}
-                onChange={(e) => setEditHours(filterNumeric(e.target.value))}
+                onChange={(e) =>
+                  setEditHours(filterNumericInput(e.target.value))
+                }
               />
               <span
                 className={`font-bold text-gray-800 font-mono ${
@@ -421,7 +417,9 @@ export default function TimerCard({
                     : "w-8 sm:w-12 text-2xl sm:text-3xl"
                 }`}
                 value={editMinutes}
-                onChange={(e) => setEditMinutes(filterNumeric(e.target.value))}
+                onChange={(e) =>
+                  setEditMinutes(filterNumericInput(e.target.value))
+                }
               />
               <span
                 className={`font-bold text-gray-800 font-mono ${
@@ -440,7 +438,9 @@ export default function TimerCard({
                     : "w-8 sm:w-12 text-2xl sm:text-3xl"
                 }`}
                 value={editSeconds}
-                onChange={(e) => setEditSeconds(filterNumeric(e.target.value))}
+                onChange={(e) =>
+                  setEditSeconds(filterNumericInput(e.target.value))
+                }
               />
             </div>
           ) : (

--- a/src/utils/timerUtils.ts
+++ b/src/utils/timerUtils.ts
@@ -1,0 +1,49 @@
+import type { TimerStatus } from "../TimerCard";
+
+export function formatTime(totalSeconds: number): string {
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:${String(
+    s
+  ).padStart(2, "0")}`;
+}
+
+export function secondsToHMS(totalSeconds: number): {
+  hours: number;
+  minutes: number;
+  seconds: number;
+} {
+  return {
+    hours: Math.floor(totalSeconds / 3600),
+    minutes: Math.floor((totalSeconds % 3600) / 60),
+    seconds: totalSeconds % 60,
+  };
+}
+
+export function hmsToSeconds(
+  hours: number,
+  minutes: number,
+  seconds: number
+): number {
+  return hours * 3600 + minutes * 60 + seconds;
+}
+
+export function filterNumericInput(value: string): string {
+  return value.replace(/[^0-9]/g, "");
+}
+
+export function getRingColor(status: TimerStatus, timeLeft: number): string {
+  if (status === "idle") return "#7c5cff";
+  if (timeLeft <= 5) return "#ef4444";
+  if (timeLeft <= 10) return "#eab308";
+  return "#7c5cff";
+}
+
+export function calculateProgress(
+  status: TimerStatus,
+  timeLeft: number,
+  initialTime: number
+): number {
+  return status === "idle" ? 1 : initialTime > 0 ? timeLeft / initialTime : 0;
+}


### PR DESCRIPTION
## Summary
- Extracts duplicated logic from `TimerCard.tsx` and `EditTimer.tsx` into a single `src/utils/timerUtils.ts` module.
- New helpers: `formatTime`, `secondsToHMS`, `hmsToSeconds`, `filterNumericInput`, `getRingColor`, `calculateProgress`.
- Both components now consume the shared utilities — no behavior change.

Closes #15

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — passes
- [x] `npm test` — 104/104 tests pass
- [ ] Manual smoke: start/pause/edit a timer in the browser