### PR TITLE
Persist timers to localStorage across refresh

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,6 +4,10 @@ import userEvent from "@testing-library/user-event";
 import App from "./App";
 
 describe("Focus Timer", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it("should display the Timer heading and subtitle", () => {
     render(<App />);
     expect(screen.getByText("Timer")).toBeInTheDocument();
@@ -613,6 +617,66 @@ describe("Focus Timer", () => {
 
       expect(screen.getByRole("dialog")).toBeInTheDocument();
       expect(screen.getByText("00:02:00")).toBeInTheDocument();
+    });
+  });
+
+  describe("Persistence", () => {
+    it("should save timers to localStorage when state changes", () => {
+      render(<App />);
+      fireEvent.click(screen.getByRole("button", { name: /add new timer/i }));
+
+      const raw = localStorage.getItem("timer-app:timers");
+      expect(raw).not.toBeNull();
+      const saved = JSON.parse(raw!);
+      expect(saved).toHaveLength(2);
+    });
+
+    it("should restore timers from localStorage on load", () => {
+      localStorage.setItem(
+        "timer-app:timers",
+        JSON.stringify([
+          {
+            id: "1",
+            label: "Timer 1",
+            timeLeft: 600,
+            initialTime: 600,
+            status: "idle",
+            sessions: 3,
+          },
+        ])
+      );
+
+      render(<App />);
+      expect(screen.getByText("00:10:00")).toBeInTheDocument();
+      expect(screen.getByText("3")).toBeInTheDocument();
+    });
+
+    it("should fall back to a default timer when localStorage is corrupted", () => {
+      localStorage.setItem("timer-app:timers", "not json{");
+      render(<App />);
+      expect(screen.getByText("00:02:00")).toBeInTheDocument();
+    });
+
+    it("should reset a running timer to idle on reload", () => {
+      localStorage.setItem(
+        "timer-app:timers",
+        JSON.stringify([
+          {
+            id: "1",
+            label: "Timer 1",
+            timeLeft: 30,
+            initialTime: 120,
+            status: "running",
+            sessions: 0,
+          },
+        ])
+      );
+
+      render(<App />);
+      expect(screen.getByText("00:02:00")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /start/i })
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import EditTimer from "./EditTimer";
 import TimerCard, { type TimerData } from "./TimerCard";
 
 const DEFAULT_TIME = 120;
+const STORAGE_KEY = "timer-app:timers";
 
 let nextId = 1;
 function createTimer(): TimerData {
@@ -17,8 +18,42 @@ function createTimer(): TimerData {
   };
 }
 
+function loadTimers(): TimerData[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [createTimer()];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed) || parsed.length === 0) return [createTimer()];
+    const timers = parsed.map((t): TimerData => {
+      const initialTime =
+        typeof t.initialTime === "number" ? t.initialTime : DEFAULT_TIME;
+      const wasRunning = t.status === "running";
+      return {
+        id: String(t.id),
+        label: typeof t.label === "string" ? t.label : `Timer ${t.id}`,
+        initialTime,
+        timeLeft: wasRunning
+          ? initialTime
+          : typeof t.timeLeft === "number"
+            ? t.timeLeft
+            : initialTime,
+        status: t.status === "paused" ? "paused" : "idle",
+        sessions: typeof t.sessions === "number" ? t.sessions : 0,
+      };
+    });
+    const maxId = timers.reduce(
+      (max, t) => Math.max(max, Number(t.id) || 0),
+      0
+    );
+    nextId = maxId + 1;
+    return timers;
+  } catch {
+    return [createTimer()];
+  }
+}
+
 export default function App() {
-  const [timers, setTimers] = useState<TimerData[]>([createTimer()]);
+  const [timers, setTimers] = useState<TimerData[]>(loadTimers);
   const [editingId, setEditingId] = useState<string | null>(null);
 
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -66,6 +101,12 @@ export default function App() {
     } else {
       document.title = "Timer";
     }
+  }, [timers]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(timers));
+    } catch {}
   }, [timers]);
 
   const updateTimer = useCallback((id: string, updates: Partial<TimerData>) => {


### PR DESCRIPTION
Closes #9

## Summary
- Load timers from localStorage on mount; fall back to a default timer when data is missing or corrupted
- Save timers to localStorage on every state change
- Reset running timers to idle on reload (real-time countdown can't be persisted across reloads)
- Continue id sequence past loaded timers so new timers don't collide with restored ones

## Test plan
- [x] All 108 unit tests pass (4 new persistence tests added in `App.test.tsx`)
- [x] Verified manually: edits, custom durations, and session counts survive a refresh
- [x] Verified manually: clearing the `timer-app:timers` localStorage entry falls back to a single default timer