### PR TITLE
Use Date.now() for accurate countdown

### DIFF
--- a/src/TimerCard.tsx
+++ b/src/TimerCard.tsx
@@ -19,6 +19,7 @@ export interface TimerData {
   initialTime: number;
   status: TimerStatus;
   sessions: number;
+  endsAt?: number | null;
 }
 
 interface TimerCardProps {

--- a/src/hooks/useTimers.test.ts
+++ b/src/hooks/useTimers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useTimers } from "./useTimers";
 
@@ -163,6 +163,102 @@ describe("useTimers", () => {
       act(() => result.current.handleLabelChange(id, "Focus"));
 
       expect(result.current.timers[0].label).toBe("Focus");
+    });
+  });
+
+  describe("Date.now() accuracy", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("starting a timer sets endsAt = now + timeLeft seconds", () => {
+      vi.setSystemTime(new Date(1_000_000_000_000));
+      const { result } = renderHook(() => useTimers());
+      const id = result.current.timers[0].id;
+      const initial = result.current.timers[0].timeLeft;
+
+      act(() => result.current.handleStart(id));
+
+      expect(result.current.timers[0].endsAt).toBe(
+        1_000_000_000_000 + initial * 1000
+      );
+    });
+
+    it("derives timeLeft from endsAt on each tick (no drift)", () => {
+      vi.setSystemTime(new Date(0));
+      const { result } = renderHook(() => useTimers());
+      const id = result.current.timers[0].id;
+
+      act(() => result.current.handleStart(id));
+
+      // Advance 60s — display should be exactly 60s less, regardless of tick scheduling
+      act(() => {
+        vi.advanceTimersByTime(60_000);
+      });
+
+      expect(result.current.timers[0].timeLeft).toBe(60);
+    });
+
+    it("recovers correctly when system clock jumps forward (background tab)", () => {
+      vi.setSystemTime(new Date(0));
+      const { result } = renderHook(() => useTimers());
+      const id = result.current.timers[0].id;
+
+      act(() => result.current.handleStart(id));
+
+      // Simulate the tab being backgrounded for 30s with no ticks firing,
+      // then a single tick after the clock has advanced
+      vi.setSystemTime(new Date(30_000));
+      act(() => {
+        vi.advanceTimersByTime(1_000);
+      });
+
+      // Display reflects real elapsed time, not number of ticks
+      expect(result.current.timers[0].timeLeft).toBeLessThanOrEqual(89);
+      expect(result.current.timers[0].timeLeft).toBeGreaterThanOrEqual(88);
+    });
+
+    it("pause freezes timeLeft based on Date.now()", () => {
+      vi.setSystemTime(new Date(0));
+      const { result } = renderHook(() => useTimers());
+      const id = result.current.timers[0].id;
+
+      act(() => result.current.handleStart(id));
+
+      vi.setSystemTime(new Date(5_000));
+      act(() => result.current.handlePause(id));
+
+      const frozen = result.current.timers[0].timeLeft;
+      expect(frozen).toBe(115);
+      expect(result.current.timers[0].endsAt).toBeNull();
+
+      // Time passes while paused — value must not change
+      vi.setSystemTime(new Date(60_000));
+      act(() => {
+        vi.advanceTimersByTime(1_000);
+      });
+      expect(result.current.timers[0].timeLeft).toBe(115);
+    });
+
+    it("resume recomputes endsAt from frozen timeLeft", () => {
+      vi.setSystemTime(new Date(0));
+      const { result } = renderHook(() => useTimers());
+      const id = result.current.timers[0].id;
+
+      act(() => result.current.handleStart(id));
+
+      vi.setSystemTime(new Date(5_000));
+      act(() => result.current.handlePause(id));
+
+      vi.setSystemTime(new Date(60_000));
+      act(() => result.current.handleResume(id));
+
+      // endsAt = 60_000 + 115 * 1000 = 175_000
+      expect(result.current.timers[0].endsAt).toBe(175_000);
     });
   });
 });

--- a/src/hooks/useTimers.ts
+++ b/src/hooks/useTimers.ts
@@ -41,11 +41,28 @@ function loadTimers(): TimerData[] {
             : initialTime,
         status: t.status === "paused" ? "paused" : "idle",
         sessions: typeof t.sessions === "number" ? t.sessions : 0,
+        endsAt: null,
       };
     });
   } catch {
     return [createTimer(1)];
   }
+}
+
+function startRunning(t: TimerData): TimerData {
+  return {
+    ...t,
+    status: "running",
+    endsAt: Date.now() + t.timeLeft * 1000,
+  };
+}
+
+function pauseRunning(t: TimerData): TimerData {
+  const remaining =
+    typeof t.endsAt === "number"
+      ? Math.max(0, Math.ceil((t.endsAt - Date.now()) / 1000))
+      : t.timeLeft;
+  return { ...t, status: "paused", timeLeft: remaining, endsAt: null };
 }
 
 export function useTimers() {
@@ -58,10 +75,16 @@ export function useTimers() {
     intervalRef.current = setInterval(() => {
       setTimers((prev) => {
         let hasChanges = false;
+        const now = Date.now();
         const next = prev.map((t) => {
-          if (t.status !== "running") return t;
+          if (t.status !== "running" || typeof t.endsAt !== "number") return t;
+          const remainingSeconds = Math.max(
+            0,
+            Math.ceil((t.endsAt - now) / 1000)
+          );
+          if (remainingSeconds === t.timeLeft) return t;
           hasChanges = true;
-          if (t.timeLeft <= 1) {
+          if (remainingSeconds <= 0) {
             const audio = new Audio("/alarm.mp3");
             audio.play().catch(() => {});
             return {
@@ -69,9 +92,10 @@ export function useTimers() {
               status: "idle" as const,
               timeLeft: t.initialTime,
               sessions: t.sessions + 1,
+              endsAt: null,
             };
           }
-          return { ...t, timeLeft: t.timeLeft - 1 };
+          return { ...t, timeLeft: remainingSeconds };
         });
         return hasChanges ? next : prev;
       });
@@ -111,29 +135,36 @@ export function useTimers() {
     );
   }, []);
 
-  const handleStart = useCallback(
-    (id: string) => updateTimer(id, { status: "running" }),
-    [updateTimer]
-  );
-  const handlePause = useCallback(
-    (id: string) => updateTimer(id, { status: "paused" }),
-    [updateTimer]
-  );
-  const handleResume = useCallback(
-    (id: string) => updateTimer(id, { status: "running" }),
-    [updateTimer]
-  );
+  const handleStart = useCallback((id: string) => {
+    setTimers((prev) =>
+      prev.map((t) => (t.id === id ? startRunning(t) : t))
+    );
+  }, []);
+  const handlePause = useCallback((id: string) => {
+    setTimers((prev) =>
+      prev.map((t) => (t.id === id ? pauseRunning(t) : t))
+    );
+  }, []);
+  const handleResume = useCallback((id: string) => {
+    setTimers((prev) =>
+      prev.map((t) => (t.id === id ? startRunning(t) : t))
+    );
+  }, []);
   const handleStop = useCallback((id: string) => {
     setTimers((prev) =>
       prev.map((t) =>
-        t.id === id ? { ...t, status: "idle", timeLeft: t.initialTime } : t
+        t.id === id
+          ? { ...t, status: "idle", timeLeft: t.initialTime, endsAt: null }
+          : t
       )
     );
   }, []);
   const handleReset = useCallback((id: string) => {
     setTimers((prev) =>
       prev.map((t) =>
-        t.id === id ? { ...t, status: "idle", timeLeft: t.initialTime } : t
+        t.id === id
+          ? { ...t, status: "idle", timeLeft: t.initialTime, endsAt: null }
+          : t
       )
     );
   }, []);
@@ -165,23 +196,17 @@ export function useTimers() {
       setTimers((prev) => {
         const running = prev.find((t) => t.status === "running");
         if (running) {
-          return prev.map((t) =>
-            t.id === running.id ? { ...t, status: "paused" as const } : t
-          );
+          return prev.map((t) => (t.id === running.id ? pauseRunning(t) : t));
         }
 
         const paused = prev.find((t) => t.status === "paused");
         if (paused) {
-          return prev.map((t) =>
-            t.id === paused.id ? { ...t, status: "running" as const } : t
-          );
+          return prev.map((t) => (t.id === paused.id ? startRunning(t) : t));
         }
 
         const idle = prev.find((t) => t.status === "idle" && t.timeLeft > 0);
         if (idle) {
-          return prev.map((t) =>
-            t.id === idle.id ? { ...t, status: "running" as const } : t
-          );
+          return prev.map((t) => (t.id === idle.id ? startRunning(t) : t));
         }
 
         return prev;


### PR DESCRIPTION
Closes #38

## Summary
Switches the countdown from `setInterval`-driven decrement to a `Date.now()`-derived calculation so timers stay accurate over long durations and across browser-tab throttling.

- Adds optional `endsAt: number | null` to `TimerData` — wall-clock ms when the timer should hit 0
- Tick recomputes `timeLeft = ceil((endsAt - now) / 1000)` instead of subtracting 1 each fire
- `handleStart` / `handleResume` set `endsAt = Date.now() + timeLeft * 1000`
- `handlePause` freezes `timeLeft` from current `Date.now()` and clears `endsAt`
- `handleStop` / `handleReset` / completion clear `endsAt`
- `loadTimers` strips `endsAt` (running timers already reset to idle on reload)
- Space-key shortcut uses the same helpers, so it correctly preserves accuracy

## Why
A 25-minute timer using the old approach drifted by 5–15 seconds depending on browser load. With `Date.now()` as the source of truth, the displayed time is always derived from the wall clock — late ticks no longer compound.

## Test plan
- [x] `npm test` — 150 tests pass (5 new accuracy tests covering `endsAt` math, drift-free ticks, background-tab clock jump, pause/resume)
- [x] `npm run build` — clean
- [ ] Manual smoke: start a 5-min timer, compare with phone stopwatch — should agree within 100ms; background the tab for 30s, verify display jumps to correct remaining