### PR TITLE
feat: zero-pad inline edit and add arrow key wrap (#35)

### DIFF
--- a/src/TimerCard.test.tsx
+++ b/src/TimerCard.test.tsx
@@ -218,9 +218,9 @@ describe("TimerCard", () => {
     it("should pre-fill inputs with current time values", async () => {
       render(<TimerCard {...createProps()} />);
       await userEvent.click(screen.getByLabelText("Click to edit time"));
-      expect(screen.getByLabelText("edit hours")).toHaveValue("0");
-      expect(screen.getByLabelText("edit minutes")).toHaveValue("2");
-      expect(screen.getByLabelText("edit seconds")).toHaveValue("0");
+      expect(screen.getByLabelText("edit hours")).toHaveValue("00");
+      expect(screen.getByLabelText("edit minutes")).toHaveValue("02");
+      expect(screen.getByLabelText("edit seconds")).toHaveValue("00");
     });
 
     it("should call onInlineEdit on Enter key", async () => {
@@ -233,6 +233,47 @@ describe("TimerCard", () => {
       await userEvent.keyboard("{Enter}");
       expect(props.onInlineEdit).toHaveBeenCalledWith("1", 300);
     });
+    it("should wrap minutes from 59 to 00 on ArrowUp", async () => {
+      const props = createProps();
+      render(<TimerCard {...props} />);
+      await userEvent.click(screen.getByLabelText("Click to edit time"));
+      const minutesInput = screen.getByLabelText("edit minutes");
+      await userEvent.clear(minutesInput);
+      await userEvent.type(minutesInput, "59");
+      await userEvent.keyboard("{ArrowUp}");
+      expect(minutesInput).toHaveValue("00");
+    });
+    it("should wrap minutes from 00 to 59 on ArrowDown", async () => {
+      const props = createProps();
+      render(<TimerCard {...props} />);
+      await userEvent.click(screen.getByLabelText("Click to edit time"));
+      const minutesInput = screen.getByLabelText("edit minutes");
+      await userEvent.clear(minutesInput);
+      await userEvent.type(minutesInput, "00");
+      await userEvent.keyboard("{ArrowDown}");
+      expect(minutesInput).toHaveValue("59");
+    });
+    it("should wrap hours from 168 to 00 on ArrowUp", async () => {
+      const props = createProps();
+      render(<TimerCard {...props} />);
+      await userEvent.click(screen.getByLabelText("Click to edit time"));
+      const hoursInput = screen.getByLabelText("edit hours");
+      await userEvent.clear(hoursInput);
+      await userEvent.type(hoursInput, "168");
+      await userEvent.keyboard("{ArrowUp}");
+      expect(hoursInput).toHaveValue("00");
+    });
+    it("should wrap hours from 00 to 168 on ArrowDown", async () => {
+      const props = createProps();
+      render(<TimerCard {...props} />);
+      await userEvent.click(screen.getByLabelText("Click to edit time"));
+      const hoursInput = screen.getByLabelText("edit hours");
+      await userEvent.clear(hoursInput);
+      await userEvent.type(hoursInput, "00");
+      await userEvent.keyboard("{ArrowDown}");
+      expect(hoursInput).toHaveValue("168");
+    });
+    
 
     it("should cancel edit on Escape key", async () => {
       const props = createProps();

--- a/src/TimerCard.tsx
+++ b/src/TimerCard.tsx
@@ -78,10 +78,29 @@ export default function TimerCard({
 
   function startEditing() {
     if (status !== "idle") return;
-    setEditHours(String(hours));
-    setEditMinutes(String(minutes));
-    setEditSeconds(String(seconds));
+    setEditHours(String(hours).padStart(2, "0"));
+    setEditMinutes(String(minutes).padStart(2, "0"));
+    setEditSeconds(String(seconds).padStart(2, "0"));
     setIsEditing(true);
+  }
+
+  function handleArrowKey(
+    e: React.KeyboardEvent,
+    current: string,
+    setValue: (v: string) => void,
+    max: number,
+  ) {
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setValue(String((Number(current) + 1) % (max + 1)).padStart(2, "0"));
+    }
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setValue(
+        String((Number(current) - 1 + (max + 1)) % (max + 1)).padStart(2, "0"),
+      );
+    }
   }
 
   function startLabelEdit() {
@@ -157,7 +176,7 @@ export default function TimerCard({
         onPause={() => onPause(id)}
         onResume={() => onResume(id)}
         onStop={() => onStop(id)}
-      />
+      />,
     );
   }, [
     isPip,
@@ -201,7 +220,7 @@ export default function TimerCard({
             const style = pipWindow.document.createElement("style");
             for (const rule of sheet.cssRules) {
               style.appendChild(
-                pipWindow.document.createTextNode(rule.cssText)
+                pipWindow.document.createTextNode(rule.cssText),
               );
             }
             pipWindow.document.head.appendChild(style);
@@ -212,7 +231,7 @@ export default function TimerCard({
       }
 
       const fontLinks = document.querySelectorAll(
-        'link[href*="fonts.googleapis.com"], link[href*="fonts.gstatic.com"]'
+        'link[href*="fonts.googleapis.com"], link[href*="fonts.gstatic.com"]',
       );
       fontLinks.forEach((link) => {
         pipWindow.document.head.appendChild(link.cloneNode(true));
@@ -234,7 +253,7 @@ export default function TimerCard({
           onPause={() => onPause(id)}
           onResume={() => onResume(id)}
           onStop={() => onStop(id)}
-        />
+        />,
       );
 
       setIsPip(true);
@@ -400,6 +419,9 @@ export default function TimerCard({
                 onChange={(e) =>
                   setEditHours(filterNumericInput(e.target.value))
                 }
+                onKeyDown={(e) =>
+                  handleArrowKey(e, editHours, setEditHours, 168)
+                }
               />
               <span
                 className={`font-bold text-gray-800 font-mono ${
@@ -421,6 +443,9 @@ export default function TimerCard({
                 onChange={(e) =>
                   setEditMinutes(filterNumericInput(e.target.value))
                 }
+                onKeyDown={(e) =>
+                  handleArrowKey(e, editMinutes, setEditMinutes, 59)
+                }
               />
               <span
                 className={`font-bold text-gray-800 font-mono ${
@@ -441,6 +466,9 @@ export default function TimerCard({
                 value={editSeconds}
                 onChange={(e) =>
                   setEditSeconds(filterNumericInput(e.target.value))
+                }
+                onKeyDown={(e) =>
+                  handleArrowKey(e, editSeconds, setEditSeconds, 59)
                 }
               />
             </div>


### PR DESCRIPTION
## Summary
- Pad hours/minutes/seconds to 2 digits when entering inline edit mode
- ArrowUp/ArrowDown increment/decrement the focused field with wrap-around (minutes/seconds 0-59, hours 0-168)
- Update existing pre-fill test for new padded values
- Add 4 wrap-around tests for ArrowUp/ArrowDown on minutes and hours

Closes #35

## Test plan
- [x] All existing tests pass (161 total)
- [x] Click `00:00:00` in idle state → see `00 : 00 : 00`
- [x] ArrowUp on minutes from 59 wraps to 00
- [x] ArrowDown on minutes from 00 wraps to 59
- [x] ArrowUp on hours from 168 wraps to 00
- [x] ArrowDown on hours from 00 wraps to 168
- [x] Hours displays 2-digit minimum but allows 3 (e.g., `02`, `168`)
- [x] Typing still accepts only digits
- [x] Enter saves, Escape reverts, blur saves (unchanged)